### PR TITLE
Docs: Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,18 +1,19 @@
 cff-version: 1.2.0
-title: Authoring Open Science
-message: >-
-  Please cite this lesson using the information in this file
-  when you refer to it in publications, and/or if you
-  re-use, adapt, or expand on the content in your own
-  training material.
-type: lesson
+message: "If you use this lesson, please cite it as below."
+type: dataset
+title: "Authoring Open Science"
 authors:
-  - given-names: Kathryn
-    family-names: Miller
-  - given-names: Andrea
-    family-names: Medina-Smith
-abstract: >-
-  This lesson introduces open science practices in writing, publishing, and reviewing scholarly research.
-  Learners will explore open authoring tools, understand contributor roles, and examine how transparency
-  supports reproducibility, collaboration, and equity in research.
+  - family-names: Miller
+    given-names: Kathryn
+  - family-names: Medina-Smith
+    given-names: Andrea
+abstract: "Focuses on integrating open science values—trust, transparency, and reproducibility—into the authoring and reviewing processes. Covers open authoring tools, contributor roles, ethics of authorship, and open peer review."
+keywords:
+  - open science
+  - writing
+  - metadata
+  - open peer review
+  - ethics
 license: CC-BY-4.0
+repository-code: "https://github.com/ucla-imls-open-sci/lc-authoring-open-science"
+url: "https://ucla-imls-open-sci.info/lc-authoring-open-science/"


### PR DESCRIPTION
This PR adds a CITATION.cff file to make the lesson citable, generated from the IMLS Open Science project metadata.